### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/example-yarn-workspace-1/package.json
+++ b/packages/example-yarn-workspace-1/package.json
@@ -4,5 +4,10 @@
   "dependencies": {
     "example-yarn-workspace-2": "^1.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bdwain/example-yarn-workspaces.git",
+    "directory":"packages/example-yarn-workspace-1"
+  },
   "main": "index.js"
 }

--- a/packages/example-yarn-workspace-2/package.json
+++ b/packages/example-yarn-workspace-2/package.json
@@ -5,5 +5,10 @@
   "dependencies": {
     "left-pad": "1.1.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bdwain/example-yarn-workspaces.git",
+    "directory":"packages/example-yarn-workspace-2"
+  },
   "main": "index.js"
 }

--- a/packages/example-yarn-workspace-3/package.json
+++ b/packages/example-yarn-workspace-3/package.json
@@ -7,6 +7,11 @@
   "devDependencies": {
     "left-pad": "1.1.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bdwain/example-yarn-workspaces.git",
+    "directory":"packages/example-yarn-workspace-3"
+  },
   "main": "index.js",
   "scripts": {
     "postinstall": "echo foo > ./temp.out"

--- a/packages/example-yarn-workspace-4/package.json
+++ b/packages/example-yarn-workspace-4/package.json
@@ -5,5 +5,10 @@
     "example-yarn-workspace-3": "^1.0.0",
     "left-pad": "1.1.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bdwain/example-yarn-workspaces.git",
+    "directory":"packages/example-yarn-workspace-4"
+  },
   "main": "index.js"
 }

--- a/packages/example-yarn-workspace-5/package.json
+++ b/packages/example-yarn-workspace-5/package.json
@@ -4,5 +4,10 @@
   "devDependencies": {
     "example-yarn-workspace-2": "^1.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bdwain/example-yarn-workspaces.git",
+    "directory":"packages/example-yarn-workspace-5"
+  },
   "main": "index.js"
 }

--- a/packages/example-yarn-workspace-6/package.json
+++ b/packages/example-yarn-workspace-6/package.json
@@ -4,5 +4,10 @@
   "devDependencies": {
     "example-yarn-workspace-5": "^1.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bdwain/example-yarn-workspaces.git",
+    "directory":"packages/example-yarn-workspace-6"
+  },
   "main": "index.js"
 }


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* example-yarn-workspace-1
* example-yarn-workspace-2
* example-yarn-workspace-3
* example-yarn-workspace-4
* example-yarn-workspace-5
* example-yarn-workspace-6